### PR TITLE
handle disabled wifi status

### DIFF
--- a/src/gateway_gatt_char_wifi_status.erl
+++ b/src/gateway_gatt_char_wifi_status.erl
@@ -83,4 +83,6 @@ value_to_binary(online) ->
 value_to_binary(false) ->
     value_to_binary(idle);
 value_to_binary(idle) ->
-    <<"idle">>.
+    <<"idle">>;
+value_to_binary(disabled) ->
+    <<"disabled">>.


### PR DESCRIPTION
```
# cat /var/log/gateway_config/console.log 
1970-01-01 00:04:39.834 [info] <0.517.0>@gatt_advertisement:handle_info:99 Started advertisement gateway_gatt_advertisement
1970-01-01 00:04:39.870 [error] <0.522.0>@gateway_gatt_char_wifi_status:value_to_binary:79 CRASH REPORT Process <0.522.0> with 0 neighbours crashed with reason: no function clause matching gateway_gatt_char_wifi_status:value_to_binary(disabled) line 79

=CRASH REPORT==== 1-Jan-1970::00:18:05.524577 ===
  crasher:
    initial call: ebus_object:init/1
    pid: <0.522.0>
    registered_name: []
    exception error: no function clause matching 
                     gateway_gatt_char_wifi_status:value_to_binary(disabled) (/home/frank/nextgate/rootfs/output/build/gateway-config-0aebbe01b391f4bad54f630fd32a71e101f7e792/src/gateway_gatt_char_wifi_status.erl, line 79)
      in function  gateway_gatt_char_wifi_status:init/2 (/home/frank/nextgate/rootfs/output/build/gateway-config-0aebbe01b391f4bad54f630fd32a71e101f7e792/src/gateway_gatt_char_wifi_status.erl, line 33)
      in call from gatt_characteristic:init/1 (/home/frank/nextgate/rootfs/output/build/gateway-config-0aebbe01b391f4bad54f630fd32a71e101f7e792/_build/default/lib/gatt/src/gatt_characteristic.erl, line 53)
      in call from gatt_service:start_characteristic/2 (/home/frank/nextgate/rootfs/output/build/gateway-config-0aebbe01b391f4bad54f630fd32a71e101f7e792/_build/default/lib/gatt/src/gatt_service.erl, line 217)
      in call from gatt_service:'-init/1-fun-0-'/2 (/home/frank/nextgate/rootfs/output/build/gateway-config-0aebbe01b391f4bad54f630fd32a71e101f7e792/_build/default/lib/gatt/src/gatt_service.erl, line 85)
      in call from lists:foldl/3 (lists.erl, line 1263)
      in call from gatt_service:init/1 (/home/frank/nextgate/rootfs/output/build/gateway-config-0aebbe01b391f4bad54f630fd32a71e101f7e792/_build/default/lib/gatt/src/gatt_service.erl, line 83)
      in call from ebus_object:init/1 (/home/frank/nextgate/rootfs/output/build/gateway-config-0aebbe01b391f4bad54f630fd32a71e101f7e792/_build/default/lib/ebus/src/ebus_object.erl, line 76)
    ancestors: [<0.520.0>,<0.514.0>,gatt_sup,<0.489.0>]
    message_queue_len: 1
    messages: [enable_wifi]
    links: [<0.520.0>]
    dictionary: []
    trap_exit: false
    status: running
    heap_size: 2586
    stack_size: 27
    reductions: 491
  neighbours:
```