### PR TITLE
Synchronize GPS and system time

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -31,7 +31,7 @@
  {<<"stillir">>,{pkg,<<"stillir">>,<<"1.0.0">>},1},
  {<<"ubx">>,
   {git,"https://github.com/helium/erlang-ubx",
-       {ref,"b7fa515811fc8e9bebc581f747ccfbab067bc3da"}},
+       {ref,"c8fa749b4feb33b4ba7a6b267d471d6d0e1ae4d7"}},
   0},
  {<<"worker_pool">>,{pkg,<<"worker_pool">>,<<"3.1.1">>},1}]}.
 [

--- a/src/gateway_config_worker.erl
+++ b/src/gateway_config_worker.erl
@@ -110,9 +110,8 @@ set_system_time(UbxPid) ->
         {ok, {nav_timeutc, #{datetime := {{Year, Month, Day}, {Hour, Min, Sec}}}}} ->
             Ymd = io_lib:format("~b-~2..0b-~2..0b", [Year, Month, Day]),
             Hms = io_lib:format("~2..0b:~2..0b:~2..0b", [Hour, Min, Sec]),
-            DateCmd = "date -s '" ++ Ymd ++ " " ++ Hms ++ "'",
-            lager:info(DateCmd),
-            os:cmd(DateCmd);
+            lager:debug("Setting date to ~p ~p", [Ymd, Hms]),
+            os:cmd("date -s '" ++ Ymd ++ " " ++ Hms ++ "'");
         _ ->
             lager:warning("No valid UTC datetime found")
     end.

--- a/src/gateway_config_worker.erl
+++ b/src/gateway_config_worker.erl
@@ -110,8 +110,9 @@ set_system_time(UbxPid) ->
         {ok, {nav_timeutc, #{datetime := {{Year, Month, Day}, {Hour, Min, Sec}}}}} ->
             Ymd = io_lib:format("~b-~2..0b-~2..0b", [Year, Month, Day]),
             Hms = io_lib:format("~2..0b:~2..0b:~2..0b", [Hour, Min, Sec]),
-            io:format("date -s '" ++ Ymd ++ "T" ++ Hms ++ "Z'"),
-            os:cmd("date -s '" ++ Ymd ++ "T" ++ Hms ++ "Z'");
+            DateCmd = "date -s '" ++ Ymd ++ "T" ++ Hms ++ "Z'",
+            lager:info(DateCmd),
+            os:cmd(DateCmd);
         _ ->
             lager:warning("No valid UTC datetime found")
     end.

--- a/src/gateway_config_worker.erl
+++ b/src/gateway_config_worker.erl
@@ -100,10 +100,12 @@ init_button(Args) ->
 set_system_datetime(UbxPid) ->
     case ubx:poll_message(UbxPid, nav_timeutc) of
         {ok, {nav_timeutc, #{datetime := {{Year, Month, Day}, {Hour, Min, Sec}}}}} ->
-            Ymd = io_lib:format("~b-~2..0b-~2..0b", [Year, Month, Day]),
+            Ymd = io_lib:format("~b~2..0b~2..0b", [Year, Month, Day]),
             Hms = io_lib:format("~2..0b:~2..0b:~2..0b", [Hour, Min, Sec]),
-            io:format("date +%Y%m%d -s ~p~n", [Ymd]),
-            io:format("date +%T -s ~p", [Hms]);
+            io:format("date +%Y%m%d -s \"" ++ Ymd ++ "\""),
+            io:format("date +%T -s \"" ++ Hms ++ "\""),
+            os:cmd("date +%Y%m%d -s \"" ++ Ymd ++ "\""),
+            os:cmd("date +%T -s \"" ++ Hms ++ "\"");
         _ ->
             lager:warning("No valid UTC datetime found")
     end.

--- a/src/gateway_config_worker.erl
+++ b/src/gateway_config_worker.erl
@@ -110,7 +110,7 @@ set_system_time(UbxPid) ->
         {ok, {nav_timeutc, #{datetime := {{Year, Month, Day}, {Hour, Min, Sec}}}}} ->
             Ymd = io_lib:format("~b-~2..0b-~2..0b", [Year, Month, Day]),
             Hms = io_lib:format("~2..0b:~2..0b:~2..0b", [Hour, Min, Sec]),
-            DateCmd = "date -s '" ++ Ymd ++ "T" ++ Hms ++ "Z'",
+            DateCmd = "date -s '" ++ Ymd ++ " " ++ Hms ++ "'",
             lager:info(DateCmd),
             os:cmd(DateCmd);
         _ ->

--- a/src/gateway_config_worker.erl
+++ b/src/gateway_config_worker.erl
@@ -110,7 +110,7 @@ set_system_time(UbxPid) ->
         {ok, {nav_timeutc, #{datetime := {{Year, Month, Day}, {Hour, Min, Sec}}}}} ->
             Ymd = io_lib:format("~b-~2..0b-~2..0b", [Year, Month, Day]),
             Hms = io_lib:format("~2..0b:~2..0b:~2..0b", [Hour, Min, Sec]),
-            lager:debug("Setting date to ~p ~p", [Ymd, Hms]),
+            lager:info("Setting date to ~p ~p", [Ymd, Hms]),
             os:cmd("date -s '" ++ Ymd ++ " " ++ Hms ++ "'");
         _ ->
             lager:warning("No valid UTC datetime found")


### PR DESCRIPTION
If system time is from 1970 then set system time to GPS time.  Otherwise, set GPS time to system time so a GPS lock can be acquired faster.