### PR TITLE
Add last 4 digits of MAC to Hotspot Name in BLE list

### DIFF
--- a/src/gateway_ble_advertisement.erl
+++ b/src/gateway_ble_advertisement.erl
@@ -22,4 +22,5 @@ include_tx_power(_) ->
     true.
 
 local_name(_) ->
-    "Helium Hotspot".
+    Serial = gateway_config:serial_number(),
+    "Helium Hotspot " ++ lists:nthtail(length(Serial) - 5, Serial).


### PR DESCRIPTION
Story details: https://app.clubhouse.io/hlm/story/1376