### PR TITLE
Move connmant:start_agent closer to connect

### DIFF
--- a/src/gateway_config_sup.erl
+++ b/src/gateway_config_sup.erl
@@ -32,8 +32,6 @@ start_link() ->
 %% Child :: {Id,StartFunc,Restart,Shutdown,Type,Modules}
 init([]) ->
     {ok, B} = ebus:system(),
-    %% Set up this connman to be the agent for authorization requests
-    ok = connman:start_agent(),
     ConfigArgs = application:get_all_env(gateway_config),
     SupFlags = {one_for_all, 3, 10},
     ChildSpecs = [

--- a/src/gateway_gatt_service.erl
+++ b/src/gateway_gatt_service.erl
@@ -4,6 +4,8 @@
 
 -behavior(gatt_service).
 
+-define(CONNMAN_AGENT_RETRY, 5000).
+
 -export([init/1, uuid/0, handle_info/2]).
 
 -record(state, {
@@ -44,7 +46,7 @@ handle_info({changed_wifi_ssid, Value}, State=#state{}) ->
 handle_info({changed_wifi_pass, _}, State=#state{ssid=""}) ->
     lager:notice("Not connecting to an empty SSID"),
     {noreply, State};
-handle_info({changed_wifi_pass, Value}, State=#state{}) ->
+handle_info({changed_wifi_pass, Value}=Msg, State=#state{}) ->
     %% To aid the gatt online notifications we fetch all services that
     %% are wifi and online or ready and attempt to disconnect them
     %% before we try to connect to the SSID stored in the state.
@@ -62,12 +64,22 @@ handle_info({changed_wifi_pass, Value}, State=#state{}) ->
                           connman:disconnect(wifi, Name)
                   end, OnlineWifiPaths),
     lager:info("Trying to connect to WiFI SSID: ~p", [State#state.ssid]),
-    case connman:connect(wifi, State#state.ssid, binary_to_list(Value), self()) of
-        ok -> ok;
-        Other ->
-            lager:notice("Start connect for SSID ~p: ~p", [State#state.ssid, Other])
-    end,
-    {noreply, State};
+    %% Start the connman agent if it was not already started.On
+    %% failure to start the agent we try to restart it later and
+    %% re-attempt the connect.
+    case connman:start_agent() of
+        ok ->
+            case connman:connect(wifi, State#state.ssid, binary_to_list(Value), self()) of
+                ok -> ok;
+                Other ->
+                    lager:notice("Start connect for SSID ~p: ~p", [State#state.ssid, Other])
+            end,
+            {noreply, State};
+        {error, Error} ->
+            lager:warning("Failed to start connman agent; ~p", [Error]),
+            erlang:send_after(?CONNMAN_AGENT_RETRY, self(), Msg),
+            {noreply, State}
+    end;
 handle_info({connect_result, _Tech, Result}, State=#state{}) ->
     lager:info("Connect result ~p", [Result]),
     {noreply, State};


### PR DESCRIPTION
This moves the actual starting of the connman agent to right before it
is needed to connect to a WiFi network.