### PR TITLE
Use a touch file for lights_off

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -18,7 +18,7 @@
 
  {gateway_config,
   [
-   {base_dir, "data"},
+   {lights_off, "/tmp/gateway_lights_off"},
    {gps, [
           {filename, "spidev1.0"},
           {gpio, 68}

--- a/rebar.config
+++ b/rebar.config
@@ -34,7 +34,6 @@
 ]}.
 
 {deps, [
-        {jsx, "2.9.0"},
         {h3, ".*", {git, "https://github.com/helium/erlang-h3.git", {branch, "master"}}},
         {ubx, ".*", {git, "https://github.com/helium/erlang-ubx", {branch, "master"}}},
         {ebus, ".*", {git, "https://github.com/helium/ebus", {branch, "master"}}},

--- a/src/gateway_config.app.src
+++ b/src/gateway_config.app.src
@@ -13,7 +13,6 @@
     connman,
     ubx,
     clique,
-    jsx,
     dogstatsd
    ]},
   {env,[]},

--- a/src/gateway_config_sup.erl
+++ b/src/gateway_config_sup.erl
@@ -32,12 +32,11 @@ start_link() ->
 %% Child :: {Id,StartFunc,Restart,Shutdown,Type,Modules}
 init([]) ->
     {ok, B} = ebus:system(),
-    ConfigArgs = application:get_all_env(gateway_config),
     SupFlags = {one_for_all, 3, 10},
     ChildSpecs = [
                   #{
                     id => gateway_config_worker,
-                    start => {gateway_config_worker, start_link, [B, ConfigArgs]},
+                    start => {gateway_config_worker, start_link, [B]},
                     type => worker,
                     restart => permanent
                   },

--- a/src/gateway_config_worker.erl
+++ b/src/gateway_config_worker.erl
@@ -29,6 +29,7 @@
                 gps_sat_info=[] :: [ubx:nav_sat()],
                 download_info=false :: boolean(),
                 lights_off_file :: string(),
+                lights_enable :: boolean()
                }).
 
 gps_info() ->


### PR DESCRIPTION
Uses a touch file instead of a config file, and places it in a shared location so that gateway_status can see it too. In development that's in `/tmp/gateway_lights_off` and in production in `/var/data/gateway_lights_off`