### PR TITLE
Allow for longer wifi lists

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -22,7 +22,7 @@
   1},
  {<<"gatt">>,
   {git,"https://github.com/helium/ebus-gatt",
-       {ref,"d1e0b6ba67a8504a2bb777015602e90b41b4b4e6"}},
+       {ref,"70110add975e4d3de4c6618e1b5d700876c6c375"}},
   0},
  {<<"getopt">>,{pkg,<<"getopt">>,<<"1.0.1">>},2},
  {<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},

--- a/src/gateway_gatt_char_add_gateway.erl
+++ b/src/gateway_gatt_char_add_gateway.erl
@@ -8,7 +8,7 @@
 -export([init/2,
          uuid/1,
          flags/1,
-         read_value/1,
+         read_value/2,
          write_value/2,
          start_notify/1,
          stop_notify/1]).
@@ -35,7 +35,7 @@ init(Path, [Proxy]) ->
         ],
     {ok, Descriptors, #state{path=Path, proxy=Proxy}}.
 
-read_value(State=#state{}) ->
+read_value(State=#state{}, _) ->
     {ok, State#state.value, State}.
 
 write_value(State=#state{}, Bin) ->
@@ -129,7 +129,7 @@ success_test() ->
     Msg = #gateway_add_gateway_v1_pb{owner=Owner, fee=Fee, amount=Amount},
     EncodedMsg = gateway_gatt_char_add_gateway_pb:encode_msg(Msg),
     {ok, Char2} = ?MODULE:write_value(Char1, EncodedMsg),
-    ?assertEqual({ok, BinTxn, Char2}, ?MODULE:read_value(Char2)),
+    ?assertEqual({ok, BinTxn, Char2}, ?MODULE:read_value(Char2, #{})),
 
     {ok, Char3} = ?MODULE:stop_notify(Char2),
     ?assertEqual({ok, Char3}, ?MODULE:stop_notify(Char3)),
@@ -157,7 +157,7 @@ error_test() ->
                         Msg = #gateway_add_gateway_v1_pb{owner=ErrorName, fee=1, amount=10},
                         EncodedMsg = gateway_gatt_char_add_gateway_pb:encode_msg(Msg),
                         {ok, NewState} = ?MODULE:write_value(State, EncodedMsg),
-                        ?assertEqual({ok, Value, NewState}, ?MODULE:read_value(NewState)),
+                        ?assertEqual({ok, Value, NewState}, ?MODULE:read_value(NewState, #{})),
                         NewState
                   end, Char,
                  [
@@ -169,7 +169,7 @@ error_test() ->
 
     InvalidReqBin = <<"invalid">>,
     {ok, Char2} = ?MODULE:write_value(Char, InvalidReqBin),
-    ?assertEqual({ok, <<"badargs">>, Char2}, ?MODULE:read_value(Char2)),
+    ?assertEqual({ok, <<"badargs">>, Char2}, ?MODULE:read_value(Char2, #{})),
 
     ?assert(meck:validate(ebus_proxy)),
     meck:unload(ebus_proxy),

--- a/src/gateway_gatt_char_lights.erl
+++ b/src/gateway_gatt_char_lights.erl
@@ -7,7 +7,7 @@
 -export([init/2,
          uuid/1,
          flags/1,
-         read_value/1,
+         read_value/2,
          write_value/2,
          start_notify/1,
          stop_notify/1]).
@@ -33,7 +33,7 @@ init(Path, []) ->
         ],
     {ok, Descriptors, #state{path=Path}}.
 
-read_value(State=#state{}) ->
+read_value(State=#state{}, _) ->
     {ok, State#state.value, State}.
 
 write_value(State=#state{}, Bin) ->
@@ -100,17 +100,17 @@ off_test() ->
     ?assertEqual({ok, Char1}, ?MODULE:start_notify(Char1)),
 
     {ok, Char2} = ?MODULE:write_value(Char1, <<"off">>),
-    ?assertEqual({ok, <<"off">>, Char2}, ?MODULE:read_value(Char2)),
+    ?assertEqual({ok, <<"off">>, Char2}, ?MODULE:read_value(Char2, #{})),
 
     %% Write an invalid value and ensure off remains
     {ok, Char2} = ?MODULE:write_value(Char2, <<"invalid">>),
-    ?assertEqual({ok, <<"off">>, Char2}, ?MODULE:read_value(Char2)),
+    ?assertEqual({ok, <<"off">>, Char2}, ?MODULE:read_value(Char2, #{})),
 
     {ok, Char3} = ?MODULE:stop_notify(Char2),
     ?assertEqual({ok, Char3}, ?MODULE:stop_notify(Char3)),
 
     {ok, Char4} = ?MODULE:write_value(Char3, <<"on">>),
-    ?assertEqual({ok, <<"on">>, Char4}, ?MODULE:read_value(Char4)),
+    ?assertEqual({ok, <<"on">>, Char4}, ?MODULE:read_value(Char4, #{})),
 
     ?assert(meck:validate(gatt_characteristic)),
     meck:unload(gatt_characteristic),

--- a/src/gateway_gatt_char_pubkey.erl
+++ b/src/gateway_gatt_char_pubkey.erl
@@ -7,7 +7,7 @@
 -export([init/2,
          uuid/1,
          flags/1,
-         read_value/1]).
+         read_value/2]).
 
 -record(state, {
                  path :: ebus:object_path(),
@@ -29,7 +29,7 @@ init(Path, [Proxy]) ->
         ],
     {ok, Descriptors, #state{path=Path, proxy=Proxy}}.
 
-read_value(State=#state{}) ->
+read_value(State=#state{}, _) ->
     Value = case ebus_proxy:call(State#state.proxy, ?MINER_OBJECT(?MINER_MEMBER_PUBKEY)) of
                 {ok, [PubKeyB58]} ->  list_to_binary(PubKeyB58);
                 {error, "org.freedesktop.DBus.Error.ServiceUnknown"} ->
@@ -62,7 +62,7 @@ read_test() ->
                 fun(proxy, ?MINER_OBJECT(?MINER_MEMBER_PUBKEY)) ->
                         {ok, [PubKey]}
                 end),
-    ?assertEqual({ok, list_to_binary(PubKey), Char}, ?MODULE:read_value(Char)),
+    ?assertEqual({ok, list_to_binary(PubKey), Char}, ?MODULE:read_value(Char, #{})),
 
    ?assert(meck:validate(ebus_proxy)),
     meck:unload(ebus_proxy),
@@ -80,7 +80,7 @@ error_test() ->
 
    lists:foldl(fun({ErrorName, Value}, State) ->
                        put({?MODULE, meck_error}, ErrorName),
-                       ?assertEqual({ok, Value, State}, ?MODULE:read_value(State)),
+                       ?assertEqual({ok, Value, State}, ?MODULE:read_value(State, #{})),
                        State
                end, Char,
                [

--- a/src/gateway_gatt_char_wifi_ssid.erl
+++ b/src/gateway_gatt_char_wifi_ssid.erl
@@ -3,9 +3,12 @@
 
 -behavior(gatt_characteristic).
 
--export([init/2, uuid/1, flags/1,
-         read_value/1,
-         start_notify/1, stop_notify/1,
+-export([init/2,
+         uuid/1,
+         flags/1,
+         read_value/2,
+         start_notify/1,
+         stop_notify/1,
          handle_signal/3]).
 
 -record(state, { path :: ebus:object_path(),
@@ -44,7 +47,7 @@ stop_notify(State=#state{notify=false}) ->
 stop_notify(State=#state{}) ->
     {ok, State#state{notify=false}}.
 
-read_value(State=#state{value=Value}) ->
+read_value(State=#state{value=Value}, _) ->
     {ok, Value, State}.
 
 
@@ -181,7 +184,7 @@ services_test() ->
     ?assertEqual({ok, Char2}, ?MODULE:start_notify(Char2)),
 
     %% Read the value
-    {ok, Result, Char3} = ?MODULE:read_value(Char2),
+    {ok, Result, Char3} = ?MODULE:read_value(Char2, #{}),
     ?assertEqual(list_to_binary(element(1, hd(Services))), Result),
 
     %% Try notifying and reading some new services
@@ -194,7 +197,7 @@ services_test() ->
                                                 end,
                                 %% The signal handler would already have refreshed the value, so
                                 %% no state change
-                                ?assertEqual({ok, ExpectedValue, NewState}, ?MODULE:read_value(NewState)),
+                                ?assertEqual({ok, ExpectedValue, NewState}, ?MODULE:read_value(NewState, #{})),
                                 NewState
                         end, Char3,
                         [
@@ -225,7 +228,7 @@ services_test() ->
                                  ExpectedValue = list_to_binary(element(1, hd(NewServices))),
                                  %% The signal handler would already have refreshed the value, so
                                  %% no state change
-                                 ?assertEqual({ok, ExpectedValue, NewState}, ?MODULE:read_value(NewState)),
+                                 ?assertEqual({ok, ExpectedValue, NewState}, ?MODULE:read_value(NewState, #{})),
                                  NewState
                          end, Char5,
                          [


### PR DESCRIPTION
The updated gatt module allows for offset based read_value which is
used for wifi_services to handle long wifi lists