### PR TITLE
Add ble cli to get list of devices

### DIFF
--- a/src/cli/gateway_config_cli_ble.erl
+++ b/src/cli/gateway_config_cli_ble.erl
@@ -1,0 +1,84 @@
+-module(gateway_config_cli_ble).
+
+-behavior(clique_handler).
+
+-export([register_cli/0]).
+
+register_cli() ->
+    register_all_usage(),
+    register_all_cmds().
+
+
+register_all_usage() ->
+    lists:foreach(fun(Args) ->
+                          apply(clique, register_usage, Args)
+                  end,
+                  [
+                   ble_usage(),
+                   ble_devices_usage()
+                  ]).
+
+register_all_cmds() ->
+    lists:foreach(fun(Cmds) ->
+                          [apply(clique, register_command, Cmd) || Cmd <- Cmds]
+                  end,
+                  [
+                   ble_cmd(),
+                   ble_devices_cmd()
+                  ]).
+
+%%
+%% ble
+%%
+
+ble_usage() ->
+    [["ble"],
+     ["ble commands\n\n",
+      "  devices - Lists all devices known to BLE.\n"
+     ]
+    ].
+
+ble_cmd() ->
+    [
+     [["ble"], [], [], fun(_, _, _) -> usage end]
+    ].
+
+
+%%
+%% ble devices
+%%
+
+ble_devices_cmd() ->
+    [
+     [["ble", "devices"], [],
+      [
+       {connected, [{shortname, "c"}, {longname, "connected"}]}
+      ], fun ble_devices/3]
+    ].
+
+ble_devices_usage() ->
+    [["ble", "devices"],
+     ["ble devices \n\n",
+      "  Get the current list of devices BLE has connected with\n",
+      "  --connected\n",
+      "  Return true or false if any device is connected to BLE\n"
+     ]
+    ].
+
+ble_devices(["ble", "devices"], [], [{connected, _}]) ->
+    {ok, AllDevices} = gateway_config:ble_device_info(),
+    case lists:filter(fun(#{"Connected" := true}) -> true;
+                         (_) -> false
+                      end, AllDevices) of
+        [] -> [clique_status:text("false")];
+        _ ->  [clique_status:text("true")]
+    end;
+ble_devices(["ble", "devices"], [], []) ->
+    {ok, AllDevices} = gateway_config:ble_device_info(),
+    FormatDevice = fun(#{"Name" := Name,
+                         "Address" := Address,
+                         "Paired" := Paired,
+                         "Connected" := Connected}) ->
+                           [{address, Address}, {name, Name}, {paired, Paired}, {connected, Connected}]
+                    end,
+    [clique_status:table([FormatDevice(D) || D <- AllDevices])].

--- a/src/cli/gateway_config_cli_registry.erl
+++ b/src/cli/gateway_config_cli_registry.erl
@@ -5,7 +5,8 @@
                       gateway_config_cli_download,
                       gateway_config_cli_advertise,
                       gateway_config_cli_lights,
-                      gateway_config_cli_wifi
+                      gateway_config_cli_wifi,
+                      gateway_config_cli_ble
                      ]).
 
 -export([register_cli/0, command/1]).

--- a/src/gateway_config.erl
+++ b/src/gateway_config.erl
@@ -6,7 +6,8 @@
          download_info/0, download_info/1,
          wifi_services/0, wifi_services_online/0,
          advertising_enable/1, advertising_info/0,
-         lights_enable/1, lights_info/0]).
+         lights_enable/1, lights_info/0,
+         ble_device_info/0]).
 
 firmware_version() ->
     case file:read_file("/etc/lsb_release") of
@@ -90,6 +91,9 @@ advertising_enable(Enable) ->
 
 advertising_info() ->
     gateway_config_worker:advertising_info().
+
+ble_device_info() ->
+    gateway_config_worker:ble_device_info().
 
 lights_enable(Enable) ->
     gateway_config_worker:lights_enable(Enable).


### PR DESCRIPTION
`ble devices` shows the table of all previously or currently paired
and/or connected devices. The `--connected` options is a utility that
returns true if there's currently a device connected and false if no
device is connected. 

This can be used in other scripts to check whether a user is connected to a gateway by issuing

```
gateway_config ble devices --connected
```

and checking whether the result is `true` or `false`. If the command errors out, you can pretty safely assume that the user is not connected at that time