### PR TITLE
Disable long button press

### DIFF
--- a/src/gpio_button.erl
+++ b/src/gpio_button.erl
@@ -6,8 +6,6 @@
                owner :: pid(),
                gpio :: pid(),
                gpio_num :: pos_integer(),
-               %%long_press_timer :: reference(),
-               %%long_press_timeout :: pos_integer(),
                click_timer :: reference(),
                click_timeout :: pos_integer(),
                click_count=0 :: non_neg_integer()
@@ -39,10 +37,8 @@ init([GpioNum, Owner, Options]) ->
     gpio:register_int(Gpio),
     gpio:set_int(Gpio, both),
 
-    %%LongPressTimeout = proplists:get_value(long_press_timeout, Options, ?DEFAULT_LONG_PRESS_TIMEOUT),
     ClickTimeout = proplists:get_value(click_timeout, Options, ?DEFAULT_CLICK_TIMEOUT),
     {ok, idle, #data{owner=Owner, gpio=Gpio, gpio_num=GpioNum,
-                     %%long_press_timer=make_ref(), long_press_timeout=LongPressTimeout,
                      click_timer=make_ref(), click_timeout=ClickTimeout
                     }}.
 
@@ -94,20 +90,15 @@ handle_event(EventType, Msg, #data{}) ->
 -spec button_pressed(#data{}) -> #data{}.
 button_pressed(Data=#data{}) ->
     erlang:cancel_timer(Data#data.click_timer),
-    %%erlang:cancel_timer(Data#data.long_press_timer),
-    %%Timer = erlang:send_after(Data#data.long_press_timeout, self(), long_press_timeout),
-    %%Data#data{long_press_timer=Timer}.
     Data#data{}.
 
 -spec button_idle(#data{}) -> #data{}.
 button_idle(Data=#data{}) ->
     erlang:cancel_timer(Data#data.click_timer),
-    %%erlang:cancel_timer(Data#data.long_press_timer),
     Data#data{click_count=0}.
 
 -spec button_clicked(#data{}) -> #data{}.
 button_clicked(Data=#data{}) ->
-    %%erlang:cancel_timer(Data#data.long_press_timer),
     erlang:cancel_timer(Data#data.click_timer),
     Timer = erlang:send_after(Data#data.click_timeout, self(), click_timeout),
     Data#data{click_count=Data#data.click_count + 1, click_timer=Timer}.

--- a/src/gpio_button.erl
+++ b/src/gpio_button.erl
@@ -6,8 +6,8 @@
                owner :: pid(),
                gpio :: pid(),
                gpio_num :: pos_integer(),
-               long_press_timer :: reference(),
-               long_press_timeout :: pos_integer(),
+               %%long_press_timer :: reference(),
+               %%long_press_timeout :: pos_integer(),
                click_timer :: reference(),
                click_timeout :: pos_integer(),
                click_count=0 :: non_neg_integer()
@@ -39,10 +39,10 @@ init([GpioNum, Owner, Options]) ->
     gpio:register_int(Gpio),
     gpio:set_int(Gpio, both),
 
-    LongPressTimeout = proplists:get_value(long_press_timeout, Options, ?DEFAULT_LONG_PRESS_TIMEOUT),
+    %%LongPressTimeout = proplists:get_value(long_press_timeout, Options, ?DEFAULT_LONG_PRESS_TIMEOUT),
     ClickTimeout = proplists:get_value(click_timeout, Options, ?DEFAULT_CLICK_TIMEOUT),
     {ok, idle, #data{owner=Owner, gpio=Gpio, gpio_num=GpioNum,
-                     long_press_timer=make_ref(), long_press_timeout=LongPressTimeout,
+                     %%long_press_timer=make_ref(), long_press_timeout=LongPressTimeout,
                      click_timer=make_ref(), click_timeout=ClickTimeout
                     }}.
 
@@ -94,19 +94,20 @@ handle_event(EventType, Msg, #data{}) ->
 -spec button_pressed(#data{}) -> #data{}.
 button_pressed(Data=#data{}) ->
     erlang:cancel_timer(Data#data.click_timer),
-    erlang:cancel_timer(Data#data.long_press_timer),
-    Timer = erlang:send_after(Data#data.long_press_timeout, self(), long_press_timeout),
-    Data#data{long_press_timer=Timer}.
+    %%erlang:cancel_timer(Data#data.long_press_timer),
+    %%Timer = erlang:send_after(Data#data.long_press_timeout, self(), long_press_timeout),
+    %%Data#data{long_press_timer=Timer}.
+    Data#data{}.
 
 -spec button_idle(#data{}) -> #data{}.
 button_idle(Data=#data{}) ->
     erlang:cancel_timer(Data#data.click_timer),
-    erlang:cancel_timer(Data#data.long_press_timer),
+    %%erlang:cancel_timer(Data#data.long_press_timer),
     Data#data{click_count=0}.
 
 -spec button_clicked(#data{}) -> #data{}.
 button_clicked(Data=#data{}) ->
-    erlang:cancel_timer(Data#data.long_press_timer),
+    %%erlang:cancel_timer(Data#data.long_press_timer),
     erlang:cancel_timer(Data#data.click_timer),
     Timer = erlang:send_after(Data#data.click_timeout, self(), click_timeout),
     Data#data{click_count=Data#data.click_count + 1, click_timer=Timer}.


### PR DESCRIPTION
Hotspot still advertises when button is pressed.

```
2015-10-18 00:03:10.560 [info] <0.559.0>@gateway_config_worker:handle_info:240 Button clicked
2015-10-18 00:03:10.560 [info] <0.559.0>@gateway_config_worker:handle_info:245 Enabling advertising
2015-10-18 00:03:12.575 [info] <0.582.0>@ble_advertisement:handle_info:99 Started advertisement gateway_ble_advertisement
2019-04-23 18:35:23.632 [info] <0.559.0>@gateway_config_worker:handle_info:261 Timeout advertising
2019-04-23 18:35:23.632 [info] <0.559.0>@gateway_config_worker:handle_info:253 Disable advertising
2019-04-23 18:35:23.632 [info] <0.582.0>@ble_advertisement:terminate:111 Stopping advertisement gateway_ble_advertisement
```

LED still turns blue then back to green after 5 minutes.
