### PR TITLE
Update README for developing on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 # gateway-config
 
 The Helium configuration application. Manages the configuration of the
-Helium Hotspot over Bluetooth, and ties together various services over
-dbus.
+Helium Hotspot over Bluetooth, and ties together various services over dbus.
 
 
   * [Features](#features)
@@ -16,26 +15,28 @@ dbus.
 
 ## Features
 
-  * Exposes a GATT BLE tree for configuring the hotspot over bluetooth
-  * Signals gateway configuration over dbus (Enabled QRCode based
-    registration)
+  * Exposes a GATT BLE tree for configuring the hotspot over Bluetooth.
+  * Signals gateway configuration (public key and Wi-Fi credentials) over dbus.
   * Listens for GPS location on SPI and signals the current Position
     of the hotspot over dbus.
-  * SOON: Exposes an LED challenge service to authorize hotspot
-    configuration over bluetooth
 
 ## Install
 
-Make sure you have dbus installed and running on your machine if you
-intend to run this in development.
+To build this project, make sure you have libdbus-1-dev (or its equivalent)
+and cmake installed on your development machine.
+
+To run this project, make sure you have dbus, bluez and connman installed
+and running on your development machine.
 
 Clone the repo and make a release of the package:
 
 ``` shell
+git clone https://github.com/helium/gateway-config.git
+cd gateway-config
 make && make release
 ```
 
-Copy the generated release into it's final destination.
+Copy the generated release to its final destination.
 
 ``` shell
 cp -R _build/prod/rel/gateway_config /opt/gateway_config
@@ -52,22 +53,27 @@ cp -R _build/prod/rel/gateway_config/config/com.helium.Config.conf /etc/dbus-1/s
 Restart dbus to pick up the new configuration. This varies per Linux
 distribution.
 
-On the Helium Hotspot the gateway-config service is started as part of
-system boot.
-
-On a void-linux development system:
+On a Void Linux development system:
 
 ``` shell
 sudo sv restart dbus
 ```
 
-Start the gateway-config service. On the Helium Hotspot the service is
-started on system init.
+Start the gateway-config service.
+
+On the Helium Hotspot the service is started on system boot.
 
 On a development system you can start the service by starting a rebar shell:
 
 ``` shell
-./rebar3 shell
+sudo ./rebar3 shell
+```
+
+Or `cd` to the release directory and run the service in the background:
+
+``` shell
+cd _build/prod/rel/gateway_config
+sudo bin/gateway_config start
 ```
 
 <!-- Badges -->

--- a/rebar.config
+++ b/rebar.config
@@ -75,7 +75,7 @@
                    {copy, "scripts/extensions/advertise", "bin/extensions/advertise"},
                    {copy, "scripts/extensions/lights", "bin/extensions/lights"},
                    {template, "config/vm.args", "{{output_dir}}/releases/{{release_version}}/vm.args"},
-                   {copy, "config/com.helium.Config.conf", "config/com.helum.Config.conf"}
+                   {copy, "config/com.helium.Config.conf", "config/com.helium.Config.conf"}
                   ]},
         {dev_mode, true},
         {sys_config, "config/sys.config"}


### PR DESCRIPTION
I reviewed the README for this repo to see if I can still build and run `gateway_config` on my Ubuntu 18.04 laptop.  I found and fixed a few issues.

- Installing `com.helium.Config.conf` to `/etc/dbus-1/system.d` failed because the destination file name was misspelled in `rebar.config`. 
- Building `ebus` failed because `libdbus-1-dev` was not installed.
- Building `h3` failed because `cmake` was not installed.
- Repeating "Failed to get connected state" errors appeared in `console.log` because `connman` was not installed and running.
- Service failed to start from a non-root environment without `sudo`.

I did not install `connman` on my Ubuntu 18.04 laptop because it conflicts with the default Network Manager.  I'm guessing Void Linux fairs better in that respect.