### PR TITLE
Add payer to ble messages

### DIFF
--- a/src/gateway_gatt_char_add_gateway.proto
+++ b/src/gateway_gatt_char_add_gateway.proto
@@ -4,4 +4,5 @@ message add_gateway_v1 {
     string owner = 1;
     uint64 amount = 2;
     uint64 fee = 3;
+    string payer = 4;
 }

--- a/src/gateway_gatt_char_assert_loc.erl
+++ b/src/gateway_gatt_char_assert_loc.erl
@@ -42,14 +42,15 @@ read_value(State=#state{}, _) ->
 
 write_value(State=#state{}, Bin) ->
     try gateway_gatt_char_assert_loc_pb:decode_msg(Bin, gateway_assert_loc_v1_pb) of
-        #gateway_assert_loc_v1_pb{lat=Lat, lon=Lon, owner=Owner, nonce=Nonce, fee=Fee, amount=Amount} ->
+        #gateway_assert_loc_v1_pb{lat=Lat, lon=Lon, owner=Owner, nonce=Nonce, fee=Fee,
+                                  amount=Amount, payer=Payer} ->
             H3Index = h3:from_geo({Lat, Lon}, ?H3_LATLON_RESOLUTION),
             H3String = h3:to_string(H3Index),
             lager:info("Requesting assert_loc_txn for lat/lon/acc: {~p, ~p, ~p} index: ~p",
                        [Lat, Lon, ?H3_LATLON_RESOLUTION, H3String]),
             Value = case ebus_proxy:call(State#state.proxy, "/", ?MINER_OBJECT(?MINER_MEMBER_ASSERT_LOC),
-                                         [string, string, uint64, uint64, uint64],
-                                         [H3String, Owner, Nonce, Amount, Fee]) of
+                                         [string, string, uint64, uint64, uint64, string],
+                                         [H3String, Owner, Nonce, Amount, Fee, Payer]) of
                         {ok, [BinTxn]} ->  BinTxn;
                         {error, Error} ->
                             lager:warning("Failed to get assert_loc txn: ~p", [Error]),
@@ -112,7 +113,8 @@ success_test() ->
     meck:new(ebus_proxy, [passthrough]),
     meck:expect(ebus_proxy, call,
                 fun(proxy, "/", ?MINER_OBJECT(?MINER_MEMBER_ASSERT_LOC),
-                    [string, string, uint64, uint64, uint64], [_Loc, _OwnerB58, _Nonce, _Amount, _Fee]) ->
+                    [string, string, uint64, uint64, uint64, string],
+                    [_Loc, _OwnerB58, _Nonce, _Amount, _Fee, _Payer]) ->
                         {ok, [BinTxn]}
                 end),
     meck:new(gatt_characteristic, [passthrough]),
@@ -148,7 +150,8 @@ error_test() ->
     meck:new(ebus_proxy, [passthrough]),
     meck:expect(ebus_proxy, call,
                 fun(proxy, "/", ?MINER_OBJECT(?MINER_MEMBER_ASSERT_LOC),
-                    [string, string, uint64, uint64, uint64], [_Loc, _OwnerB58, _Nonce, _Amount, _Fee]) ->
+                    [string, string, uint64, uint64, uint64, string],
+                    [_Loc, _OwnerB58, _Nonce, _Amount, _Fee, _Payer]) ->
                         ErrorName = get({?MODULE, meck_error}),
                         {error, ErrorName}
                 end),

--- a/src/gateway_gatt_char_assert_loc.proto
+++ b/src/gateway_gatt_char_assert_loc.proto
@@ -7,4 +7,5 @@ message assert_loc_v1 {
     uint64 nonce = 4;
     uint64 fee = 5;
     uint64 amount = 6;
+    string payer = 7;
 }

--- a/src/gateway_gatt_char_onboarding_key.erl
+++ b/src/gateway_gatt_char_onboarding_key.erl
@@ -46,7 +46,7 @@ read_value(State=#state{}, _) ->
 
 uuid_test() ->
     {ok, _, Char} = ?MODULE:init("", [proxy]),
-    ?assertEqual(?UUID_GATEWAY_GATT_CHAR_OBOARDING_KEY, ?MODULE:uuid(Char)),
+    ?assertEqual(?UUID_GATEWAY_GATT_CHAR_ONBOARDING_KEY, ?MODULE:uuid(Char)),
     ok.
 
 flags_test() ->
@@ -73,7 +73,7 @@ error_test() ->
     {ok, _, Char} = ?MODULE:init("", [proxy]),
 
     meck:expect(ebus_proxy, call,
-                fun(proxy, ?MINER_OBJECT(?MINER_MEMBER_ONBARDING_KEY)) ->
+                fun(proxy, ?MINER_OBJECT(?MINER_MEMBER_ONBOARDING_KEY)) ->
                         ErrorName = get({?MODULE, meck_error}),
                         {error, ErrorName}
                 end),


### PR DESCRIPTION
Adds the payer field to both add_gw and assert_loc BLE protobuf messages to pass along to miner 