### PR TITLE
Add offset based reads for larger txns

### DIFF
--- a/src/gateway_gatt_char_add_gateway.erl
+++ b/src/gateway_gatt_char_add_gateway.erl
@@ -35,6 +35,8 @@ init(Path, [Proxy]) ->
         ],
     {ok, Descriptors, #state{path=Path, proxy=Proxy}}.
 
+read_value(State=#state{value=Value}, #{"offset" := Offset}) ->
+    {ok, binary:part(Value, Offset, byte_size (Value) - Offset), State};
 read_value(State=#state{}, _) ->
     {ok, State#state.value, State}.
 

--- a/src/gateway_gatt_char_assert_loc.erl
+++ b/src/gateway_gatt_char_assert_loc.erl
@@ -37,6 +37,8 @@ init(Path, [Proxy]) ->
         ],
     {ok, Descriptors, #state{path=Path, proxy=Proxy}}.
 
+read_value(State=#state{value=Value}, #{"offset" := Offset}) ->
+    {ok, binary:part(Value, Offset, byte_size (Value) - Offset), State};
 read_value(State=#state{}, _) ->
     {ok, State#state.value, State}.
 


### PR DESCRIPTION
Assert loc and add gateway transactions may need to be chunked. Add offset based reads 