### PR TITLE
Fix up advertising off light logic

### DIFF
--- a/src/gateway_config_led.erl
+++ b/src/gateway_config_led.erl
@@ -199,7 +199,7 @@ update_led_state(stop_advert, State=#state{}) ->
 update_led_state(online, State=#state{state={advert, online}}) ->
     %% If we receive an online event while advertising and we were
     %% online when we started advertising, stay in advertising.
-    State#state{};
+    State;
 update_led_state(online, State=#state{state={advert, _}}) ->
     %% If we receive an online event while advertising and we were not
     %% online when we started advertising, go to online state.


### PR DESCRIPTION
The blue light indicating advertising was going to green too soon if
the hotspot was already online. The logic should be that the blue
light stays on for the duraction, except when the hotspot goes from
offline to online, in which case it goes green right away.