### PR TITLE
Keep enabling Wi-Fi until it powers on

### DIFF
--- a/src/gateway_config_worker.erl
+++ b/src/gateway_config_worker.erl
@@ -218,6 +218,7 @@ handle_info({packet, Packet}, State=#state{}) ->
 handle_info({button_clicked, _, 1}, State=#state{}) ->
     lager:info("Button clicked"),
     %% Start a scan for visible wifi services
+    connman:enable(wifi, true),
     connman:scan(wifi),
     handle_info({enable_advertising, true}, State);
 


### PR DESCRIPTION
This PR addresses Clubhouse story [#5881](https://app.clubhouse.io/hlm/story/5881/wi-fi-on-pi-4-b-does-not-always-power-on).

This fix _does_ eventually power on Wi-Fi but was taking minutes because of repeating `Device or resource busy` Wi-Fi errors.  For that reason I increased the retry interval from 2 to 10 seconds so that successive enable attempts are allowed to time out instead of canceling each other out.