### PR TITLE
Retrieve onboarding and pubkey from file

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -22,6 +22,7 @@
 
  {gateway_config,
   [
+   {keys_file, "/var/data/public_keys"},
    {lights_off, "/tmp/gateway_lights_off"},
    {gps, [
           {filename, "spidev1.0"},

--- a/include/gateway_config.hrl
+++ b/include/gateway_config.hrl
@@ -13,8 +13,6 @@
 -define(MINER_APPLICATION_NAME, "com.helium.Miner").
 -define(MINER_INTERFACE, "com.helium.Miner").
 -define(MINER_OBJECT(M), ?MINER_INTERFACE ++ "." ++ M).
--define(MINER_MEMBER_PUBKEY, "PubKey").
--define(MINER_MEMBER_ONBOARDING_KEY, "OnboardingKey").
 -define(MINER_MEMBER_ADD_GW, "AddGateway").
 -define(MINER_MEMBER_ASSERT_LOC, "AssertLocation").
 -define(MINER_MEMBER_P2P_STATUS, "P2PStatus").

--- a/src/gateway_config.erl
+++ b/src/gateway_config.erl
@@ -12,6 +12,7 @@
          advertising_enable/1, advertising_info/0,
          lights_event/1, lights_info/0,
          diagnostics/1,
+         get_public_key/1,
          ble_device_info/0]).
 
 firmware_version() ->
@@ -137,3 +138,18 @@ diagnostics(Proxy) ->
     lists:foldl(fun({Key, Val}, Acc) ->
                         lists:keystore(Key, 1, Acc, {Key, Val})
                 end, Base, P2PStatus).
+
+
+-spec get_public_key(onboarding_key | pubkey) -> {ok, string()} | {error, term()}.
+get_public_key(KeyName) ->
+    KeysFile = application:get_env(gateway_config, keys_file, "data/public_keys"),
+    case file:consult(KeysFile) of
+        {error, Error} -> {error, Error};
+        {ok, KeyList} ->
+            case proplists:get_value(KeyName, KeyList, undefined) of
+                undefined ->
+                    {error, key_not_found};
+                V ->
+                    {ok, V}
+            end
+    end.

--- a/src/gateway_gatt_char_pubkey.erl
+++ b/src/gateway_gatt_char_pubkey.erl
@@ -30,14 +30,9 @@ init(Path, [Proxy]) ->
     {ok, Descriptors, #state{path=Path, proxy=Proxy}}.
 
 read_value(State=#state{}, _) ->
-    Value = case ebus_proxy:call(State#state.proxy, ?MINER_OBJECT(?MINER_MEMBER_PUBKEY)) of
-                {ok, [PubKeyB58]} ->  list_to_binary(PubKeyB58);
-                {error, "org.freedesktop.DBus.Error.ServiceUnknown"} ->
-                    lager:warning("Miner not ready to get public key, returning waiting"),
-                    <<"wait">>;
-                {error, Error} ->
-                    lager:warning("Failed to get public key, returning unkown: ~p", [Error]),
-                    <<"unknown">>
+    Value = case gateway_config:get_public_key(pubkey) of
+                {error, _} -> <<"unknown">>;
+                {ok, V} -> list_to_binary(V)
             end,
     {ok, Value, State}.
 
@@ -57,39 +52,16 @@ flags_test() ->
 read_test() ->
     {ok, _, Char} = ?MODULE:init("", [proxy]),
 
-    PubKey = "pubkey",
-    meck:expect(ebus_proxy, call,
-                fun(proxy, ?MINER_OBJECT(?MINER_MEMBER_PUBKEY)) ->
-                        {ok, [PubKey]}
-                end),
-    ?assertEqual({ok, list_to_binary(PubKey), Char}, ?MODULE:read_value(Char, #{})),
-
-   ?assert(meck:validate(ebus_proxy)),
-    meck:unload(ebus_proxy),
+    application:set_env(gateway_config, keys_file, "test/public_keys"),
+    ?assertEqual({ok, <<"112YR4mqBrc6DxrVonKsYE6bb6TGab3K1vVfpF8yAebRSd5YgZDy">>, Char}, ?MODULE:read_value(Char, #{})),
 
     ok.
 
 error_test() ->
     {ok, _, Char} = ?MODULE:init("", [proxy]),
 
-    meck:expect(ebus_proxy, call,
-                fun(proxy, ?MINER_OBJECT(?MINER_MEMBER_PUBKEY)) ->
-                        ErrorName = get({?MODULE, meck_error}),
-                        {error, ErrorName}
-                end),
-
-   lists:foldl(fun({ErrorName, Value}, State) ->
-                       put({?MODULE, meck_error}, ErrorName),
-                       ?assertEqual({ok, Value, State}, ?MODULE:read_value(State, #{})),
-                       State
-               end, Char,
-               [
-                {"org.freedesktop.DBus.Error.ServiceUnknown", <<"wait">>},
-                {"com.unknown.Error", <<"unknown">>}
-               ]),
-
-   ?assert(meck:validate(ebus_proxy)),
-    meck:unload(ebus_proxy),
+    application:set_env(gateway_config, keys_file, "test/no_keys_file"),
+    ?assertEqual({ok, <<"unknown">>, Char}, ?MODULE:read_value(Char, #{})),
 
     ok.
 

--- a/test/public_keys
+++ b/test/public_keys
@@ -1,0 +1,2 @@
+{pubkey,"112YR4mqBrc6DxrVonKsYE6bb6TGab3K1vVfpF8yAebRSd5YgZDy"}.
+{onboarding_key, "onboarding_key"}.


### PR DESCRIPTION
This moves the retrieval for pub key and onboarding keys out of talking to miner and into a file that is expected to provisioned in a filename configured in sys.config. 

This means that gatt retrievals for pub key and onboarding key can succeed as long as the file is present. 