### PR TITLE
Delete profile for unseen network

### DIFF
--- a/include/gateway_config.hrl
+++ b/include/gateway_config.hrl
@@ -19,3 +19,5 @@
 
 -define(MINER_ERROR_BADARGS, "com.helium.Miner.Error.BadArgs").
 -define(MINER_ERROR_INTERNAL, "com.helium.Miner.Error.Internal").
+
+-define(CONNMAN_PROFILES_PATH, "/var/lib/connman/").


### PR DESCRIPTION
This PR adds a `wifi_services_named(Name)` function that takes a network name and returns a list of saved service profiles containing that network name in their `settings` file.  This function is only called in the event that `connman:remove(wifi, Name)` fails (eg. the target network is missing from the most recent Wi-Fi scan).  If `wifi_services_named(Name)` locates any saved profiles with that network name the `remove` handler then deletes them from `/var/lib/connman` using `rm -rf`.

```
# /opt/gateway_config/bin/gateway_config remote_console
Erlang/OTP 22 [erts-10.5] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1]

Eshell V10.5  (abort with ^G)
(gateway_config@127.0.0.1)1> gateway_config:wifi_services_configured().
["RT-AC66U_B1_38_5G","RT-AC66U_B1_38_2G"]
(gateway_config@127.0.0.1)2> gateway_config:wifi_services_named("RT-AC66U_B1_38_5G").
["wifi_6081f9042e73_52542d41433636555f42315f33385f3547_managed_psk"]
(gateway_config@127.0.0.1)3> gateway_config:wifi_services_named("RT-AC66U_B1_38_2G").
["wifi_6081f9042e73_52542d41433636555f42315f33385f3247_managed_psk"]
(gateway_config@127.0.0.1)4> connman:remove(wifi, "RT-AC66U_B1_38_2G").
ok
(gateway_config@127.0.0.1)5> gateway_config:wifi_services_configured().              
["RT-AC66U_B1_38_5G"]
(gateway_config@127.0.0.1)6> 
User switch command
 --> q
# connmanctl
connmanctl> services
*AO Wired                ethernet_6081f9042e72_cable
*A  RT-AC66U_B1_38_5G    wifi_6081f9042e73_52542d41433636555f42315f33385f3547_managed_psk
    RT-AC66U_B1_38_2G    wifi_6081f9042e73_52542d41433636555f42315f33385f3247_managed_psk
    Atavacron-2.4        wifi_6081f9042e73_417461766163726f6e2d322e34_managed_psk
    Mat Palace           wifi_6081f9042e73_4d61742050616c616365_managed_psk
                         wifi_6081f9042e73_hidden_managed_ieee8021x
    Le Net               wifi_6081f9042e73_4c65204e6574_managed_psk
                         wifi_6081f9042e73_hidden_none
                         wifi_6081f9042e73_hidden_managed_none
                         wifi_6081f9042e73_hidden_managed_psk
    sunshinegarden       wifi_6081f9042e73_73756e7368696e6567617264656e_managed_psk
    NETGEAR97            wifi_6081f9042e73_4e4554474541523937_managed_psk
    142b                 wifi_6081f9042e73_31343262_managed_psk
    BenPhone             wifi_6081f9042e73_42656e50686f6e65_managed_psk
    NETGEAR82            wifi_6081f9042e73_4e4554474541523832_managed_psk
    ATTcQ65Bxi           wifi_6081f9042e73_41545463513635427869_managed_psk
    ATTebskays           wifi_6081f9042e73_4154546562736b617973_managed_psk
    Vance Refrigeration _EXT wifi_6081f9042e73_56616e63652052656672696765726174696f6e205f455854_managed_psk
    VicFontainesLounge   wifi_6081f9042e73_566963466f6e7461696e65734c6f756e6765_managed_psk
connmanctl> quit
# cat /var/lib/connman/wifi_6081f9042e73_52542d41433636555f42315f33385f3247_managed_psk/settings | grep Favorite
Favorite=false
# cat /var/lib/connman/wifi_6081f9042e73_52542d41433636555f42315f33385f3547_managed_psk/settings | grep Favorite
Favorite=true
```

ConnMan won't attempt to connect to Wi-Fi networks that are no longer classified as favorites when it encounters them.  That is why "RT-AC66U_B1_38_2G" no longer appears as available in the Wi-Fi scan after removing.