### PR TITLE
Log to /var/log not /var/data/log

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -11,7 +11,7 @@
  {lager, [
           {error_logger_redirect, true},
           {suppress_supervisor_start_stop, true},
-          {log_root, "/var/data/log/gateway_config"},
+          {log_root, "/var/log/gateway_config"},
           {crash_log, "crash.log"},
           {colored, true},
           {handlers, [


### PR DESCRIPTION
The `/var/log` directory is mounted as tmpfs so it does not wear down the microSD.