### PR TITLE
Reattempt to connect to WiFi network when agent off

### DIFF
--- a/src/gateway_gatt_service.erl
+++ b/src/gateway_gatt_service.erl
@@ -73,6 +73,10 @@ handle_info({connect, wifi, Service, Pass, Char}=Msg, State=#state{}) ->
             case connman:connect(wifi, Service, Pass, self()) of
                 ok ->
                     {noreply, State#state{connect_result_char=Char}};
+                {error, "net.connman.error.NotRegistered"} ->
+                    lager:warning("Agent off connecting to SSID ~p: Retrying", [Service]),
+                    erlang:send_after(?CONNMAN_AGENT_RETRY, self(), Msg),
+                    {noreply, State};
                 Other ->
                     lager:notice("Error connecting connman to SSID ~p: ~p", [Service, Other]),
                     {noreply, State}


### PR DESCRIPTION
@tyler-whitman removed the "J&T Wireless" network from his Helium Hotspot then tried reconnecting to it.

```
2020-07-21 17:58:09.750 [info] <0.534.0>@gateway_config_worker:handle_info:226 Enabling advertising
2020-07-21 17:58:11.743 [info] <0.627.0>@ble_advertisement:handle_info:99 Started advertisement gateway_ble_advertisement
2020-07-21 17:58:48.708 [info] <0.545.0>@gateway_gatt_service:handle_info:67 Trying to connect to WiFi SSID: "J&T Wireless"
2020-07-21 17:58:48.711 [info] <0.638.0>@connman_connect:connecting:62 Connecting to "J&T Wireless" at "/net/connman/service/wifi_6081f95405a9_4a265420576972656c657373_managed_psk"
2020-07-21 17:58:48.714 [info] <0.545.0>@gateway_gatt_service:handle_info:86 Connect result {error,"net.connman.Error.NotRegistered"}
```

```
connmanctl> connect wifi_6081f95405a9_4a265420576972656c657373_managed_psk
Error /net/connman/service/wifi_6081f95405a9_4a265420576972656c657373_managed_psk: Method "Connect" with signature "" on interface "net.connman.Service" doesn't exist
connmanctl> agent on
Agent registered
connmanctl> connect wifi_6081f95405a9_4a265420576972656c657373_managed_psk
Agent RequestInput wifi_6081f95405a9_4a265420576972656c657373_managed_psk
  Passphrase = [ Type=psk, Requirement=mandatory, Alternates=[ WPS ] ]
  WPS = [ Type=wpspin, Requirement=alternate ]
Passphrase?
```