### PR TITLE
fix runtime errors

### DIFF
--- a/src/gateway_config.erl
+++ b/src/gateway_config.erl
@@ -312,8 +312,8 @@ get_public_key(KeyName) ->
     case gateway_config_miner:pubkey() of
         {ok, {PubKey, OnboardingKey}} ->
             case KeyName of
-                pubkey -> libp2p_crypto:bin_to_b58(PubKey);
-                onboarding_key -> libp2p_crypto:bin_to_b58(OnboardingKey)
+                pubkey -> {ok, libp2p_crypto:bin_to_b58(PubKey)};
+                onboarding_key -> {ok, libp2p_crypto:bin_to_b58(OnboardingKey)}
             end;
         {error, Error} ->
             {error, Error}

--- a/src/gateway_gatt_char_onboarding_key.erl
+++ b/src/gateway_gatt_char_onboarding_key.erl
@@ -13,8 +13,7 @@
 ]).
 
 -record(state, {
-    path :: ebus:object_path(),
-    proxy :: ebus:proxy()
+    path :: ebus:object_path()
 }).
 
 uuid(_) ->
@@ -23,12 +22,12 @@ uuid(_) ->
 flags(_) ->
     [read].
 
-init(Path, [Proxy]) ->
+init(Path, []) ->
     Descriptors = [
         {gatt_descriptor_cud, 0, ["Onboarding Key"]},
         {gatt_descriptor_pf, 1, [utf8_string]}
     ],
-    {ok, Descriptors, #state{path = Path, proxy = Proxy}}.
+    {ok, Descriptors, #state{path = Path}}.
 
 read_value(State = #state{}, _) ->
     Value =


### PR DESCRIPTION
1. `get_public_key` returns `KEY`, but receiver expect `TUPLE`
2. fix `gateway_gatt_char_onboarding_key` signature